### PR TITLE
Set timer when player hits ground. Can only use wind again after 0.5s…

### DIFF
--- a/ProjectWeather/Assets/Player/Scripts/MyCharacterController.cs
+++ b/ProjectWeather/Assets/Player/Scripts/MyCharacterController.cs
@@ -56,6 +56,7 @@ namespace Assets.Player.Scripts
         private Vector3 _internalVelocityAdd = Vector3.zero;
         private float _maxMoveSpeed = 10f;
         private bool _sprintActivated = false;
+        private float _timeSinceLastImpulse = 0f;
 
         // Animation and Cinemachine variables
         private float _moveSpeed;
@@ -324,14 +325,26 @@ namespace Assets.Player.Scripts
             if (_ability.IsAbilityBeingPressed(Weather.Wind) && !_impulseConsumed)
             {
                 _impulseConsumed = true;
+                _timeSinceLastImpulse = 0f;
                 Motor.ForceUnground(0.1f);
                 AddVelocity((_moveInputVector.normalized + Motor.CharacterUp) * _ability.ImpulseMagnitude);
             }
         }
 
-        private void HandleImpulseValues()
+        private void HandleImpulseValues(float deltaTime)
         {
+            // Start a timer when the player hits the ground
             if (Motor.GroundingStatus.IsStableOnGround)
+            {
+                _timeSinceLastImpulse += deltaTime;
+            }
+            else if (_timeSinceLastImpulse > 0)
+            {
+                _timeSinceLastImpulse += deltaTime;
+            }
+
+
+            if (_timeSinceLastImpulse > _ability.WindAbilitySecondsReset)
             {
                 _impulseConsumed = false;
             }
@@ -346,7 +359,7 @@ namespace Assets.Player.Scripts
             // Handle jump-related values
             HandleJumpValues(deltaTime);
 
-            HandleImpulseValues();
+            HandleImpulseValues(deltaTime);
         }
 
         public bool IsColliderValidForCollisions(Collider coll)

--- a/ProjectWeather/Assets/Scripts/Abilities/PlayerAbility.cs
+++ b/ProjectWeather/Assets/Scripts/Abilities/PlayerAbility.cs
@@ -11,6 +11,7 @@ public class PlayerAbility : MonoBehaviour
     [Header("Wind Ability")]
     public bool AllowWindAbility = true;
     public float ImpulseMagnitude = 20f;
+    public float WindAbilitySecondsReset = 0.5f;
 
     // Private variables
     private SpellParticleEffects _spellEffects;


### PR DESCRIPTION
- Added an adjustable timer to PlayerAbility.cs called ResetWindAbilitySeconds or something like that

Basically, you can use your wind ability, then as soon as you hit the ground a timer starts and you can only activate wind ability again after the timer is greater than ResetWindAbilitySeconds. So this setting can be made longer or short in the editor on the PlayerAbility.cs script. I set it to a default value of 0.5 seconds, which seems alright.